### PR TITLE
feat: make window resizable with proportional layout

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -436,19 +436,6 @@ impl eframe::App for PomodoroApp {
             ctx.request_repaint_after(Duration::from_millis(100));
         }
 
-        // Calculate window size based on notes visibility and settings dialog
-        // Ensure window is wide enough for settings dialog when it's open
-        let base_width = if self.show_settings || self.show_survey {
-            450.0 // Wide enough for settings/survey dialogs
-        } else if self.notes_enabled {
-            700.0
-        } else {
-            320.0
-        };
-        ctx.send_viewport_cmd(egui::ViewportCommand::InnerSize(egui::vec2(
-            base_width, 420.0,
-        )));
-
         // Dark theme colors
         let text_color = egui::Color32::from_rgb(0xee, 0xee, 0xee);
         let work_color = egui::Color32::from_rgb(0xe7, 0x4c, 0x3c);
@@ -673,7 +660,7 @@ impl eframe::App for PomodoroApp {
                                     ui.add(
                                         egui::TextEdit::multiline(&mut self.notes_content)
                                             .id(egui::Id::new("notes_text_input"))
-                                            .desired_width(400.0)
+                                            .desired_width(f32::INFINITY) // Use all available width
                                             .desired_rows(15)
                                             .font(egui::TextStyle::Monospace),
                                     );

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,9 @@ fn main() -> eframe::Result<()> {
 
     let options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()
-            .with_inner_size([320.0, 400.0])
+            .with_inner_size([700.0, 450.0])
+            .with_min_inner_size([320.0, 350.0])
+            .with_resizable(true)
             .with_title("Otamot")
             .with_icon(icon.unwrap_or_default()),
         ..Default::default()


### PR DESCRIPTION
## Summary

This PR implements issue #17 - making the window resizable with proportional layout adjustments.

### Changes
- Enabled window resizing via `ViewportBuilder::with_resizable(true)`
- Set minimum window size (320x350) to prevent UI collapse
- Removed fixed `InnerSize` command that was forcing window dimensions
- Changed notes `TextEdit` width to `f32::INFINITY` to fill available space
- UI elements now proportionally adjust when window is resized

### Testing
- All 76 tests pass
- `cargo fmt` and `cargo clippy` pass cleanly

Closes #17